### PR TITLE
Mock warnings in tests

### DIFF
--- a/spec/unit/recipes/account_service_spec.rb
+++ b/spec/unit/recipes/account_service_spec.rb
@@ -4,6 +4,10 @@ describe 'ilo_test::account_service_create' do
   let(:resource_name) { 'account_service' }
   include_context 'chef context'
 
+  before :each do
+    expect_any_instance_of(Kernel).to receive(:warn).with(/`ilo_account_service` is deprecated/)
+  end
+
   it 'create test account' do
     expect_any_instance_of(ILO_SDK::Client).to receive(:get_users).and_return(['user1', 'user2'])
     expect_any_instance_of(ILO_SDK::Client).to receive(:create_user).with('test', 'test123').and_return(true)
@@ -20,6 +24,10 @@ describe 'ilo_test::account_service_change_password' do
   let(:resource_name) { 'account_service' }
   include_context 'chef context'
 
+  before :each do
+    expect_any_instance_of(Kernel).to receive(:warn).with(/`ilo_account_service` is deprecated/)
+  end
+
   it 'change test account password' do
     expect_any_instance_of(ILO_SDK::Client).to receive(:get_users).and_return(['user1', 'user2', 'test'])
     expect_any_instance_of(ILO_SDK::Client).to receive(:change_password).with('test', 'newtest123').and_return(true)
@@ -35,6 +43,10 @@ end
 describe 'ilo_test::account_service_delete' do
   let(:resource_name) { 'account_service' }
   include_context 'chef context'
+
+  before :each do
+    expect_any_instance_of(Kernel).to receive(:warn).with(/`ilo_account_service` is deprecated/)
+  end
 
   it 'delete test account' do
     expect_any_instance_of(ILO_SDK::Client).to receive(:get_users).and_return(['user1', 'user2', 'test'])

--- a/spec/unit/recipes/computer_details_spec.rb
+++ b/spec/unit/recipes/computer_details_spec.rb
@@ -4,8 +4,8 @@ describe 'ilo_test::computer_details_dump' do
   let(:resource_name) { 'computer_details' }
   include_context 'chef context'
 
-  it 'dump computer details' do
-    expect_any_instance_of(ILO_SDK::Client).to receive(:get_computer_details).and_return(
+  let(:details) do
+    {
       'GeneralDetails' => {
         'manufacturer' => '',
         'model' => '',
@@ -73,7 +73,12 @@ describe 'ilo_test::computer_details_dump' do
           ]
         ]
       }
-    )
+    }
+  end
+
+  it 'dump computer details' do
+    allow(Chef::Log).to receive(:error).with(/Failed to load data bag item/).and_return true
+    expect_any_instance_of(ILO_SDK::Client).to receive(:get_computer_details).and_return(details)
     expect(real_chef_run).to dump_ilo_computer_details('dump computer details')
   end
 end

--- a/spec/unit/recipes/https_cert_spec.rb
+++ b/spec/unit/recipes/https_cert_spec.rb
@@ -25,6 +25,10 @@ describe 'ilo_test::https_cert_import' do
   let(:resource_name) { 'https_cert' }
   include_context 'chef context'
 
+  before :each do
+    expect_any_instance_of(Kernel).to receive(:warn).with(/Both certificate and file_path provided/)
+  end
+
   it 'import certificate' do
     expect_any_instance_of(ILO_SDK::Client).to receive(:get_certificate).and_return('different_example_certificate')
     expect_any_instance_of(ILO_SDK::Client).to receive(:import_certificate).with('example_certificate').and_return(true)


### PR DESCRIPTION
Mocks out warnings in unit tests so they don't pollute output.