### PR TITLE
Bios update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 2.1
   - 2.2.5
 
+before_install: gem update bundler
+
 before_script:
 - eval "$(/opt/chefdk/bin/chef shell-init bash)"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
-### 1.0.0
-Initial release
+### 1.3.0
+ - Refactored ilo_bios resource to support all settings. (Breaking Change)
+
+### 1.2.0
+ - Moved resources into libraries
+ - Added ilo_https_cert resource
 
 #### 1.0.1
-Updated metadata.rb file
+ - Updated metadata.rb file
+
+## 1.0.0
+Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'chef', '>=12.0.0'
+gem 'chef', '~> 12.5'
 gem 'chefspec'
 gem 'berkshelf'
 gem 'foodcritic'

--- a/README.md
+++ b/README.md
@@ -70,6 +70,31 @@ The following resources are available for usage in your recipes:
 
 ### ilo_bios
 
+ - **Set BIOS configuration:**
+
+  ```ruby
+  ilo_bios 'set BIOS configuration' do
+    ilos [ilo1, ilo2]
+    settings(
+      UefiShellStartup: 'Enabled',
+      UefiShellStartupLocation: 'Auto',
+      UefiShellStartupUrl: 'http://www.uefi.nsh',
+      Dhcpv4: 'Enabled',
+      Ipv4Address: '10.1.1.0',
+      Ipv4Gateway: '10.1.1.11',
+      Ipv4PrimaryDNS: '10.1.1.1',
+      Ipv4SecondaryDNS: '10.1.1.2',
+      Ipv4SubnetMask: '255.255.255.0',
+      UrlBootFile: 'http://www.urlbootfile.iso',
+      ServiceName: 'iLO Admin',
+      ServiceEmail: 'admin@domain.com'
+      # NOTE: This is just an example; you can set as many or as few settings as you want.
+      # (And there's a whole lot more you can set. See the API docs for the complete list.)
+    )
+    action :set # Not necessary, as this is the default
+  end
+  ```
+
  - **Revert to default BIOS base configuration:**
 
   ```ruby
@@ -79,38 +104,10 @@ The following resources are available for usage in your recipes:
   end
   ```
 
- - **Set BIOS configuration:**
-
-  ```ruby
-  ilo_bios 'set BIOS configuration' do
-    ilos [ilo1, ilo2]
-    uefi_shell_startup 'Enabled'
-    uefi_shell_startup_location 'Auto'
-    uefi_shell_startup_url 'http://www.uefi.nsh'
-    dhcpv4 'Disabled'
-    ipv4_address '10.1.1.0'
-    ipv4_gateway '10.1.1.11'
-    ipv4_primary_dns '10.1.1.1'
-    ipv4_secondary_dns '10.1.1.2'
-    ipv4_subnet_mask '255.255.255.0'
-    url_boot_file 'http://www.urlbootfile.iso'
-    service_name 'John Doe'
-    service_email 'john.doe@hpe.com'
-    action :set # Not necessary, as this is the default
-  end
-  ```
-
 
 ### ilo_boot_settings
 
  - **Revert to default Boot base configuration:**
-
-  ```ruby
-  ilo_boot_settings 'revert boot' do
-    ilos [ilo1, ilo2]
-    action :revert
-  end
-  ```
 
  - **Set boot configuration:**
 
@@ -127,6 +124,13 @@ The following resources are available for usage in your recipes:
     ]
     boot_target 'None'
     action :set # Not necessary, as this is the default
+  end
+  ```
+
+  ```ruby
+  ilo_boot_settings 'revert boot' do
+    ilos [ilo1, ilo2]
+    action :revert
   end
   ```
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,4 +3,4 @@
 # Attributes:: default
 #
 
-default['ilo']['ruby_sdk_version'] = '~> 1.1'
+default['ilo']['ruby_sdk_version'] = '~> 1.2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef-cookbooks@groups.ext.hpe.com'
 license          'Apache v2.0'
 description      'Configure HPE iLO'
 long_description 'Configure HPE iLO using the iLO APIs.'
-version          '1.2.0'
+version          '1.3.0'
 
 source_url       'https://github.com/HewlettPackard/ilo-chef'
 issues_url       'https://github.com/HewlettPackard/ilo-chef/issues'
@@ -28,4 +28,3 @@ supports         'smartos'
 supports         'oracle'
 
 depends          'compat_resource'
-gem              'ilo-sdk' if respond_to?(:gem)

--- a/spec/fixtures/cookbooks/ilo_test/recipes/bios_set.rb
+++ b/spec/fixtures/cookbooks/ilo_test/recipes/bios_set.rb
@@ -1,23 +1,23 @@
-ilo =
-  {
-    host: 'ilo.example.com',
-    user: 'Admin',
-    password: 'secret123'
-  }
+ilo = {
+  host: 'ilo.example.com',
+  user: 'Admin',
+  password: 'secret123'
+}
 
 ilo_bios 'set bios' do
   ilos [ilo]
-  uefi_shell_startup 'Enabled'
-  uefi_shell_startup_url 'http://www.test.nsh'
-  uefi_shell_startup_location 'NetworkLocation'
-  dhcpv4 'Enabled'
-  ipv4_address '111.111.111.111'
-  ipv4_gateway '111.111.111.111'
-  ipv4_primary_dns '111.111.111.111'
-  ipv4_secondary_dns '111.111.111.111'
-  ipv4_subnet_mask '111.111.111.111'
-  url_boot_file 'http://www.urlbootfiletest.iso'
-  service_name 'bik'
-  service_email 'bik.bajwa@hpe.com'
-  action :set
+  settings(
+    UefiShellStartup: 'Enabled',
+    UefiShellStartupLocation: 'Auto',
+    UefiShellStartupUrl: 'http://www.uefi.nsh',
+    Dhcpv4: 'Enabled',
+    Ipv4Address: '10.1.1.0',
+    Ipv4Gateway: '10.1.1.11',
+    Ipv4PrimaryDNS: '10.1.1.1',
+    Ipv4SecondaryDNS: '10.1.1.2',
+    Ipv4SubnetMask: '255.255.255.0',
+    UrlBootFile: 'http://www.urlbootfile.iso',
+    ServiceName: 'iLO Admin',
+    ServiceEmail: 'admin@domain.com'
+  )
 end

--- a/spec/unit/recipes/bios_spec.rb
+++ b/spec/unit/recipes/bios_spec.rb
@@ -20,51 +20,51 @@ describe 'ilo_test::bios_set' do
   let(:resource_name) { 'bios' }
   include_context 'chef context'
 
-  it 'set bios' do
-    expect_any_instance_of(ILO_SDK::Client).to receive(:get_uefi_shell_startup).and_return(
-      'UefiShellStartup' => 'Disabled',
-      'UefiShellStartupLocation' => '',
-      'UefiShellStartupUrl' => ''
-    )
-    expect_any_instance_of(ILO_SDK::Client).to receive(:get_bios_dhcp).and_return(
-      'Dhcpv4' => 'Disabled',
-      'Ipv4Address' => '0.0.0.0',
-      'Ipv4Gateway' => '0.0.0.0',
-      'Ipv4PrimaryDNS' => '0.0.0.0',
-      'Ipv4SecondaryDNS' => '0.0.0.0',
-      'Ipv4SubnetMask' => '0.0.0.0'
-    )
-    expect_any_instance_of(ILO_SDK::Client).to receive(:get_url_boot_file).and_return('http://wwww.fake.iso')
-    expect_any_instance_of(ILO_SDK::Client).to receive(:get_bios_service).and_return(
-      'ServiceName' => 'name',
-      'ServiceEmail' => 'email@email.com'
-    )
-    expect_any_instance_of(ILO_SDK::Client).to receive(:set_uefi_shell_startup).with('Enabled', 'NetworkLocation', 'http://www.test.nsh').and_return(true)
-    expect_any_instance_of(ILO_SDK::Client).to receive(:set_bios_dhcp).with('Enabled').and_return(true)
-    expect_any_instance_of(ILO_SDK::Client).to receive(:set_url_boot_file).with('http://www.urlbootfiletest.iso').and_return(true)
-    expect_any_instance_of(ILO_SDK::Client).to receive(:set_bios_service).with('bik', 'bik.bajwa@hpe.com').and_return(true)
+  let(:same_settings) do
+    {
+      UefiShellStartup: 'Enabled',
+      UefiShellStartupLocation: 'Auto',
+      UefiShellStartupUrl: 'http://www.uefi.nsh',
+      Dhcpv4: 'Enabled',
+      Ipv4Address: '10.1.1.0',
+      Ipv4Gateway: '10.1.1.11',
+      Ipv4PrimaryDNS: '10.1.1.1',
+      Ipv4SecondaryDNS: '10.1.1.2',
+      Ipv4SubnetMask: '255.255.255.0',
+      UrlBootFile: 'http://www.urlbootfile.iso',
+      ServiceName: 'iLO Admin',
+      ServiceEmail: 'admin@domain.com'
+    }
+  end
+
+  let(:different_settings) do
+    {
+      UefiShellStartup: 'Disabled',
+      UefiShellStartupLocation: 'Auto',
+      UefiShellStartupUrl: 'http://www.uefi2.nsh',
+      Dhcpv4: 'Enabled',
+      Ipv4Address: '0.0.0.0',
+      Ipv4Gateway: '0.0.0.0',
+      Ipv4PrimaryDNS: '0.0.0.0',
+      Ipv4SecondaryDNS: '0.0.0.0',
+      Ipv4SubnetMask: '255.255.255.0',
+      UrlBootFile: 'http://www.urlbootfile.iso',
+      ServiceName: 'iLO Admin2',
+      ServiceEmail: 'admin2@domain.com'
+    }
+  end
+
+  it 'sets BIOS settings if there are differences' do
+    current = JSON.parse(different_settings.to_json)
+    expect_any_instance_of(ILO_SDK::Client).to receive(:get_bios_settings).and_return current
+    expect_any_instance_of(ILO_SDK::Client).to receive(:set_bios_settings).with(same_settings).and_return true
     expect(real_chef_run).to set_ilo_bios('set bios')
   end
 
-  it 'does not set bios' do
-    expect_any_instance_of(ILO_SDK::Client).to receive(:get_uefi_shell_startup).and_return(
-      'UefiShellStartup' => 'Enabled',
-      'UefiShellStartupLocation' => 'NetworkLocation',
-      'UefiShellStartupUrl' => 'http://www.test.nsh'
-    )
-    expect_any_instance_of(ILO_SDK::Client).to receive(:get_bios_dhcp).and_return(
-      'Dhcpv4' => 'Enabled',
-      'Ipv4Address' => '111.111.111.111',
-      'Ipv4Gateway' => '111.111.111.111',
-      'Ipv4PrimaryDNS' => '111.111.111.111',
-      'Ipv4SecondaryDNS' => '111.111.111.111',
-      'Ipv4SubnetMask' => '111.111.111.111'
-    )
-    expect_any_instance_of(ILO_SDK::Client).to receive(:get_url_boot_file).and_return('http://www.urlbootfiletest.iso')
-    expect_any_instance_of(ILO_SDK::Client).to receive(:get_bios_service).and_return(
-      'ServiceName' => 'bik',
-      'ServiceEmail' => 'bik.bajwa@hpe.com'
-    )
+  it 'skips the update if nothing is different' do
+    current = JSON.parse(same_settings.to_json)
+    expect_any_instance_of(ILO_SDK::Client).to receive(:get_bios_settings).and_return current
+    expect_any_instance_of(ILO_SDK::Client).to_not receive(:set_bios_settings)
     expect(real_chef_run).to set_ilo_bios('set bios')
   end
 end


### PR DESCRIPTION
Fixes #8 

This updates the ilo_bios resource to have a single hash property (named 'settings'). This allows you to set any BIOS attribute that is able to be set. This relies on the new SDK methods, and reduces the number of API calls from 8 to 2. It also shows which settings were updated, including their previous and new values.

Note: The last 2 commits were to fix issues with Travis. It was using an old version of bundler on the Ruby 2.1 builds that would pull outrageously old versions of gems.