### PR TITLE
Fixed cert import (from file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 1.3.1
+ - Fixed bug in ilo_https_cert :import when importing from file.
+
 ### 1.3.0
  - Refactored ilo_bios resource to support all settings. (Breaking Change)
 

--- a/libraries/https_cert.rb
+++ b/libraries/https_cert.rb
@@ -37,7 +37,7 @@ module IloCookbook
         converge_by 'Importing new certificate' do
           client.import_certificate(certificate)
         end
-      elsif file
+      else
         cert = ::File.open(file_path).read
         next if cur_certificate.gsub(/\s+/, '') == cert.gsub(/\s+/, '')
         converge_by "Importing new certificate from '#{file_path}'" do

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef-cookbooks@groups.ext.hpe.com'
 license          'Apache v2.0'
 description      'Configure HPE iLO'
 long_description 'Configure HPE iLO using the iLO APIs.'
-version          '1.3.0'
+version          '1.3.1'
 
 source_url       'https://github.com/HewlettPackard/ilo-chef'
 issues_url       'https://github.com/HewlettPackard/ilo-chef/issues'

--- a/spec/fixtures/cookbooks/ilo_test/recipes/https_cert_import_from_file.rb
+++ b/spec/fixtures/cookbooks/ilo_test/recipes/https_cert_import_from_file.rb
@@ -1,0 +1,12 @@
+ilo1 =
+  {
+    host: 'ilo.example.com',
+    user: 'Admin',
+    password: 'secret123'
+  }
+
+ilo_https_cert 'import certificate' do
+  ilo ilo1
+  file_path '/ilo_example_file.crt'
+  action :import
+end

--- a/spec/unit/recipes/https_cert_spec.rb
+++ b/spec/unit/recipes/https_cert_spec.rb
@@ -29,14 +29,46 @@ describe 'ilo_test::https_cert_import' do
     expect_any_instance_of(Kernel).to receive(:warn).with(/Both certificate and file_path provided/)
   end
 
-  it 'import certificate' do
+  it 'imports the certificate' do
     expect_any_instance_of(ILO_SDK::Client).to receive(:get_certificate).and_return('different_example_certificate')
     expect_any_instance_of(ILO_SDK::Client).to receive(:import_certificate).with('example_certificate').and_return(true)
     expect(real_chef_run).to import_ilo_https_cert('import certificate')
   end
 
-  it 'do not import certificate' do
+  it 'does not import certificate if it is unchanged' do
     expect_any_instance_of(ILO_SDK::Client).to receive(:get_certificate).and_return('example_certificate')
+    expect_any_instance_of(ILO_SDK::Client).to_not receive(:import_certificate)
+    expect(real_chef_run).to import_ilo_https_cert('import certificate')
+  end
+end
+
+describe 'ilo_test::https_cert_import_from_file' do
+  let(:resource_name) { 'https_cert' }
+  include_context 'chef context'
+
+  # Class to help mock file reads
+  class FakeFile
+    def self.read
+      'example_certificate'
+    end
+  end
+
+  before :each do
+    # These mocks seem strange, but for some reason the duplicate and this order matters
+    allow(::File).to receive(:open).with('/ilo_example_file.crt').and_return(FakeFile)
+    allow(::File).to receive(:open).with(any_args).and_call_original
+    allow(::File).to receive(:open).with('/ilo_example_file.crt').and_return(FakeFile)
+  end
+
+  it 'imports the certificate' do
+    expect_any_instance_of(ILO_SDK::Client).to receive(:get_certificate).and_return('different_example_certificate')
+    expect_any_instance_of(ILO_SDK::Client).to receive(:import_certificate).with('example_certificate').and_return(true)
+    expect(real_chef_run).to import_ilo_https_cert('import certificate')
+  end
+
+  it 'does not import certificate if it is unchanged' do
+    expect_any_instance_of(ILO_SDK::Client).to receive(:get_certificate).and_return('example_certificate')
+    expect_any_instance_of(ILO_SDK::Client).to_not receive(:import_certificate)
     expect(real_chef_run).to import_ilo_https_cert('import certificate')
   end
 end


### PR DESCRIPTION
Fixes bug [here](https://github.com/HewlettPackard/ilo-chef/blob/2dd3709203facd66425df49778a934751699acd4/libraries/https_cert.rb#L40): the `file` variable does not exist, and the `elsif` is not necessary (just an else).