### PR TITLE
Updated Travis & Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.1
   - 2.2.5
   - 2.3.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,13 @@ source 'https://rubygems.org'
 
 gem 'chef', '~> 12.5'
 gem 'chefspec'
-gem 'berkshelf'
+if RUBY_VERSION =~ /^2\.[01]/
+  gem 'berkshelf', '~> 4.3' # Use older version of berkshelf for Ruby 2.0 and 2.1
+  # This is necessary because berkshelf 5.0 requires buff-extensions 2.0.0, which requires Ruby >= 2.2
+else
+  gem 'berkshelf'
+end
 gem 'foodcritic'
-gem 'rubocop', '= 0.40.0'
+gem 'rubocop', '= 0.42.0'
 gem 'ilo-sdk'
 gem 'pry'


### PR DESCRIPTION
Since Chef ships with Ruby 2.1, I think it's best we keep it in our tests. This fixes the issues that berkshelf 5.0 was causing for Ruby 2.1.

It also updates Rubocop to the latest.