### PR TITLE
Gh templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+### Scenario/Intent
+[What you are trying to achieve but can't?]
+
+### Environment Details
+ - **iLO Cookbook Version:** [Version of this cookbook for which you are encountering the issue]
+ - **iLO Appliance Type:** [Type of the iLO appliance you're interacting with (e.g. DL380 Gen 9)]
+ - **iLO Firmware Version:** [Firmware Version of the iLO appliance you're interacting with]
+ - **chef-client Version:** [Version of chef-client in your environment]
+ - **platform:** [OS distribution and release version. Cloud provider if applicable]
+
+### Steps to Reproduce
+[If you are filing an issue, what are the things we need to do in order to reproduce your problem? How are you using this cookbook or any resources it includes?]
+
+### Expected Result
+[What do you *expect* to happen after taking the steps above?]
+
+### Actual Result
+[What *actually* happens after the steps above? Include error output or a link to a gist.]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Description
+
+[Describe what this change achieves]
+
+### Issues Resolved
+
+[List any issues this PR will resolve]
+
+### Check List
+- [ ] New functionality includes testing.
+  - [ ] All tests pass (`$ rake test`).
+  - [ ] New resources and/or actions have are included in the [matchers.rb](../blob/master/libraries/matchers.rb).
+- [ ] New functionality has been documented in the README if applicable.
+  - [ ] New functionality has been thoroughly documented in [examples](../tree/master/examples/) (please include helpful comments).
+- [ ] Changes documented in the [CHANGELOG](../blob/master/CHANGELOG.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 ### Check List
 - [ ] New functionality includes testing.
   - [ ] All tests pass (`$ rake test`).
-  - [ ] New resources and/or actions have are included in the [matchers.rb](../blob/master/libraries/matchers.rb).
+  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/ilo-chef/blob/master/libraries/matchers.rb).
 - [ ] New functionality has been documented in the README if applicable.
-  - [ ] New functionality has been thoroughly documented in [examples](../tree/master/examples/) (please include helpful comments).
+  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/ilo-chef/tree/master/examples) (please include helpful comments).
 - [ ] Changes documented in the [CHANGELOG](../blob/master/CHANGELOG.md).

--- a/chefignore
+++ b/chefignore
@@ -58,6 +58,7 @@ Procfile
 #######
 .git
 */.git
+.github
 .gitignore
 .gitmodules
 .gitconfig


### PR DESCRIPTION
This should make it much easier to create issues and PRs, because it lets people know what is expected (and reminds us too). This applies more for code PRs, but not so much doc updates or issues opened to facilitate discussion. That's OK. It's a template, not the end-all; we can always leave sections out.