### PR TITLE
FrozenStringLiteralComment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,3 +64,6 @@ Metrics/PerceivedComplexity:
 
 Performance/Casecmp:
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
It seems there was a difference between rubocop 0.40.0 and 0.42.0, where
the Frozenstringliteralcomment was starting to be enforced.

This ignores the check.

Signed-off-by: JJ Asghar  <jj@chef.io>