### PR TITLE
Remove compat_resource and resolve some Foodcritic warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Enables configuration of HPE iLOs via their APIs.
 
 ### Requirements
 
- - Chef 12+
- - iLO 4
+- Chef 12.7+
+- iLO 4
 
 ### Cookbook Dependencies
 
- - compat_resource
+- none
 
 ### How to use the iLO Cookbook:
 

--- a/libraries/account_service.rb
+++ b/libraries/account_service.rb
@@ -17,7 +17,7 @@ module IloCookbook
     resource_name :ilo_account_service
 
     load_base_properties
-    property :username, String, required: true, name_property: true
+    property :username, String, name_property: true
     property :password, String
 
     action :create do

--- a/libraries/base_resource.rb
+++ b/libraries/base_resource.rb
@@ -11,7 +11,7 @@
 
 module IloCookbook
   # Base class for iLO resources
-  class BaseResource < ChefCompat::Resource
+  class BaseResource < Chef::Resource
     require_relative 'ilo_helper'
 
     action_class do

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -17,7 +17,7 @@ module IloCookbook
     resource_name :ilo_user
 
     load_base_properties
-    property :username, String, required: true, name_property: true
+    property :username, String, name_property: true
     property :password, String
     property :login_priv, [TrueClass, FalseClass]
     property :remote_console_priv, [TrueClass, FalseClass]

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name             'ilo'
 maintainer       'Hewlett Packard Enterprise'
 maintainer_email 'chef-cookbooks@groups.ext.hpe.com'
-license          'Apache v2.0'
+license          'Apache-2.0'
 description      'Configure HPE iLO'
 long_description 'Configure HPE iLO using the iLO APIs.'
 version          '1.3.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version          '1.3.1'
 source_url       'https://github.com/HewlettPackard/ilo-chef'
 issues_url       'https://github.com/HewlettPackard/ilo-chef/issues'
 
-chef_version     '>= 12' if respond_to?(:chef_version)
+chef_version     '>= 12.7' if respond_to?(:chef_version)
 
 supports         'windows'
 supports         'mac_os_x'
@@ -26,5 +26,3 @@ supports         'suse'
 supports         'xenserver'
 supports         'smartos'
 supports         'oracle'
-
-depends          'compat_resource'


### PR DESCRIPTION
We've deprecated the compat_resource cookbook and don't recommend that users utilize it at this point. You can just require Chef 12.7+ which came out long time ago (plus Chef 12 goes EOL next month). This also cleans up a Foodcritic warning and bumps your cookbook quality score on Supermarket a bit.